### PR TITLE
fix: suppress esmodule interop warning

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,9 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  // https://github.com/kulshekhar/ts-jest/issues/1173#issuecomment-1404142039
+  transform: {
+    '^.+\\.(ts|tsx)?$': ['ts-jest', {diagnostics: {ignoreCodes: ['TS151001']}}],
+    "^.+\\.(js|jsx)$": "babel-jest",
+  }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "esModuleInterop": true,
   "compilerOptions": {
     "rootDir": "./src"
   }


### PR DESCRIPTION
ts-jest reports a warning even when `esModuleInterop` in `tsconfig.json` is set to `true`.